### PR TITLE
Build go script with specialised flags

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -83,7 +83,6 @@ set of parameters.`,
 			indexPath = targetDir + "index.js"
 		} else {
 			buildCmd = fmt.Sprintf("GOOS=linux go build %v -o %v%v", customFlags, targetDir, functionName)
-			log.Println(buildCmd)
 			indexPath = targetDir + "index.js"
 			deployArguments = append(
 				deployArguments,


### PR DESCRIPTION
This PR enables `go-cloud-fn` to compile `go` programs with custom flags. 

I'm using the `-ldflags - X "package.varname={{varvalue}}"` to specify runtime variables for Cloud functions. This enables me to deploy custom functions based on input data. 

This [stackoverflow questi](http://stackoverflow.com/questions/11354518/golang-application-auto-build-versioning) explains the usage of `-ldflags`  a bit more thoroughly. 